### PR TITLE
Add output functionality in ISO 8601 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The reverse can also be accomplished with the output method. So pass in seconds 
     => 4 minutes 30 seconds
     >> ChronicDuration.output(270, :format => :chrono)
     => 4:30
+    >> ChronicDuration.output(270, :format => :iso)
+    => "PT4M30S"
     >> ChronicDuration.output(1299600, :weeks => true)
     => 2 wks 1 day 1 hr
     >> ChronicDuration.output(1299600, :weeks => true, :units => 2)

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -154,9 +154,9 @@ module ChronicDuration
       humanized_num = humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
-        'T' + humanized_time
+        'T' + humanized_num
       else
-        humanized_time
+        humanized_num
       end
     end.compact!
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,6 +152,7 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+      Rails.logger.info(humanized_num.inspect)
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -144,15 +144,16 @@ module ChronicDuration
       joiner = ''
     end
 
-    time_component = false
+    iso_time_part = false
     result = [:years, :months, :weeks, :days, :hours, :minutes, :seconds].map do |t|
       next if t == :weeks && !opts[:weeks]
       num = eval(t.to_s)
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
-      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !time_component && (num != 0 || keep_zero)
+      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
         res = 'T'
+        iso_time_part = true
       else
         res = ''
       end

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -133,14 +133,27 @@ module ChronicDuration
         }.join(divider).gsub(/^(00:)+/, '').gsub(/^0/, '').gsub(/:$/, '')
       end
       joiner = ''
+    when :iso
+      dividers = {
+        :years => 'Y', :months => 'M', :weeks => 'W', :days => 'D', :hours => 'H', :minutes => 'M', :seconds => 'S',
+        :iso => true
+      }
+      process = lambda do |str|
+        str.insert(0, 'P')
+      end
+      joiner = ''
     end
 
+    time_component = false
     result = [:years, :months, :weeks, :days, :hours, :minutes, :seconds].map do |t|
       next if t == :weeks && !opts[:weeks]
       num = eval(t.to_s)
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
+      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !time_component && (num != 0 || keep_zero)
+        'T'
+      end
       humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
     end.compact!
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -156,8 +156,8 @@ module ChronicDuration
         res.insert(0, 'T')
         iso_time_part = true
       end
-      #res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      #res
+      res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
+      res
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,7 +152,7 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      if ([:hours, :minutes, :seconds].include? t) && dividers[:iso] && !iso_time_part && !humanized_num.nil?
+      if dividers[:iso] && ([:hours, :minutes, :seconds].include? t) && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num
       else

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -151,11 +151,10 @@ module ChronicDuration
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
+      res = ''
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
-        res = 'T'
+        res.insert(0, 'T')
         iso_time_part = true
-      else
-        res = ''
       end
       res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
       res

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,10 +152,10 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      Rails.logger.info(t.inspect)
-      Rails.logger.info(dividers[:iso].inspect)
-      Rails.logger.info(iso_time_part.inspect)
-      Rails.logger.info(humanized_num.inspect)
+      Rails.logger.info([:hours, :minutes, :seconds].include? t)
+      Rails.logger.info(dividers[:iso])
+      Rails.logger.info(!iso_time_part)
+      Rails.logger.info(!humanized_num.nil?)
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -151,8 +151,7 @@ module ChronicDuration
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
-      humanized_num = humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
-      Rails.logger.info(humanized_num.inspect)
+      humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,9 +152,12 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !time_component && (num != 0 || keep_zero)
-        'T'
+        res = 'T'
+      else
+        res = ''
       end
-      humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
+      res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
+      res
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -156,6 +156,7 @@ module ChronicDuration
       Rails.logger.info(dividers[:iso])
       Rails.logger.info(!iso_time_part)
       Rails.logger.info(!humanized_num.nil?)
+      Rails.logger.info([:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?)
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -157,7 +157,7 @@ module ChronicDuration
         iso_time_part = true
       end
       res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      res
+      #res
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,12 +152,7 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      Rails.logger.info([:hours, :minutes, :seconds].include? t)
-      Rails.logger.info(dividers[:iso])
-      Rails.logger.info(!iso_time_part)
-      Rails.logger.info(!humanized_num.nil?)
-      Rails.logger.info([:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?)
-      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
+      if ([:hours, :minutes, :seconds].include? t) && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num
       else

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,6 +152,10 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
+      Rails.logger.info(t.inspect)
+      Rails.logger.info(dividers[:iso].inspect)
+      Rails.logger.info(iso_time_part.inspect)
+      Rails.logger.info(humanized_num.inspect)
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -153,11 +153,10 @@ module ChronicDuration
       keep_zero ||= opts[:keep_zero] if t == :seconds
       res = ''
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
-        res.insert(0, 'T')
+        res = 'T'
         iso_time_part = true
       end
-      res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      res
+      res + humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -156,7 +156,7 @@ module ChronicDuration
         res.insert(0, 'T')
         iso_time_part = true
       end
-      res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
+      #res << humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
       #res
     end.compact!
 

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,9 +152,8 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
-        res = 'T'
         iso_time_part = true
-        res + humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+        'T' + humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
       else
         humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
       end

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -152,7 +152,7 @@ module ChronicDuration
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
       humanized_num = humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
-      if dividers[:iso] && ([:hours, :minutes, :seconds].include? t) && !iso_time_part && !humanized_num.nil?
+      if dividers[:iso] && [:hours, :minutes, :seconds].include?(t) && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
         'T' + humanized_num
       else

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -151,12 +151,13 @@ module ChronicDuration
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
-      res = ''
       if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
         res = 'T'
         iso_time_part = true
+        res + humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+      else
+        humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
       end
-      res + humanize_time_unit( num, dividers[t], dividers[:pluralize], keep_zero )
     end.compact!
 
     result = result[0...opts[:units]] if opts[:units]

--- a/lib/chronic_duration.rb
+++ b/lib/chronic_duration.rb
@@ -151,11 +151,12 @@ module ChronicDuration
       num = ("%.#{decimal_places}f" % num) if num.is_a?(Float) && t == :seconds
       keep_zero = dividers[:keep_zero]
       keep_zero ||= opts[:keep_zero] if t == :seconds
-      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && (num != 0 || keep_zero)
+      humanized_num = humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+      if [:hours, :minutes, :seconds].include? t && dividers[:iso] && !iso_time_part && !humanized_num.nil?
         iso_time_part = true
-        'T' + humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+        'T' + humanized_time
       else
-        humanize_time_unit( dividers[t], dividers[:pluralize], keep_zero, dividers[:iso] )
+        humanized_time
       end
     end.compact!
 

--- a/lib/chronic_duration/version.rb
+++ b/lib/chronic_duration/version.rb
@@ -1,3 +1,3 @@
 module ChronicDuration
-  VERSION = '0.10.6'
+  VERSION = '0.10.7'
 end

--- a/spec/lib/chronic_duration_spec.rb
+++ b/spec/lib/chronic_duration_spec.rb
@@ -86,7 +86,8 @@ describe ChronicDuration do
           :short    => '1m 20s',
           :default  => '1 min 20 secs',
           :long     => '1 minute 20 seconds',
-          :chrono   => '1:20'
+          :chrono   => '1:20',
+          :iso      => 'PT1M20S'
         },
       (60 + 20.51) =>
         {
@@ -94,7 +95,8 @@ describe ChronicDuration do
           :short    => '1m 20.51s',
           :default  => '1 min 20.51 secs',
           :long     => '1 minute 20.51 seconds',
-          :chrono   => '1:20.51'
+          :chrono   => '1:20.51',
+          :iso      => 'PT1M20.51S' # Yuck. FIXME
         },
       (60 + 20.51928) =>
         {
@@ -102,7 +104,8 @@ describe ChronicDuration do
           :short    => '1m 20.51928s',
           :default  => '1 min 20.51928 secs',
           :long     => '1 minute 20.51928 seconds',
-          :chrono   => '1:20.51928'
+          :chrono   => '1:20.51928',
+          :iso      => 'PT1M20.51928S' # Yuck. FIXME
         },
       (4 * 3600 + 60 + 1) =>
         {
@@ -110,7 +113,8 @@ describe ChronicDuration do
           :short    => '4h 1m 1s',
           :default  => '4 hrs 1 min 1 sec',
           :long     => '4 hours 1 minute 1 second',
-          :chrono   => '4:01:01'
+          :chrono   => '4:01:01',
+          :iso      => 'PT4H1M1S'
         },
       (2 * 3600 + 20 * 60) =>
         {
@@ -118,7 +122,8 @@ describe ChronicDuration do
           :short    => '2h 20m',
           :default  => '2 hrs 20 mins',
           :long     => '2 hours 20 minutes',
-          :chrono   => '2:20'
+          :chrono   => '2:20',
+          :iso      => 'PT2H20M'
         },
       (2 * 3600 + 20 * 60) =>
         {
@@ -126,7 +131,8 @@ describe ChronicDuration do
           :short    => '2h 20m',
           :default  => '2 hrs 20 mins',
           :long     => '2 hours 20 minutes',
-          :chrono   => '2:20:00'
+          :chrono   => '2:20:00',
+          :iso      => 'PT2H20M'
         },
       (6 * 30 * 24 * 3600 + 24 * 3600) =>
         {
@@ -134,7 +140,8 @@ describe ChronicDuration do
           :short    => '6mo 1d',
           :default  => '6 mos 1 day',
           :long     => '6 months 1 day',
-          :chrono   => '6:01:00:00:00' # Yuck. FIXME
+          :chrono   => '6:01:00:00:00', # Yuck. FIXME
+          :iso      => 'P6M1D'
         },
       (365.25 * 24 * 3600 + 24 * 3600 ).to_i =>
         {
@@ -142,7 +149,8 @@ describe ChronicDuration do
           :short    => '1y 1d',
           :default  => '1 yr 1 day',
           :long     => '1 year 1 day',
-          :chrono   => '1:00:01:00:00:00'
+          :chrono   => '1:00:01:00:00:00',
+          :iso      => 'P1Y1D'
         },
       (3  * 365.25 * 24 * 3600 + 24 * 3600 ).to_i =>
         {
@@ -150,7 +158,8 @@ describe ChronicDuration do
           :short    => '3y 1d',
           :default  => '3 yrs 1 day',
           :long     => '3 years 1 day',
-          :chrono   => '3:00:01:00:00:00'
+          :chrono   => '3:00:01:00:00:00',
+          :iso      => 'P3Y1D'
         },
       (3600 * 24 * 30 * 18) =>
         {
@@ -158,7 +167,8 @@ describe ChronicDuration do
           :short    => '18mo',
           :default  => '18 mos',
           :long     => '18 months',
-          :chrono   => '18:00:00:00:00'
+          :chrono   => '18:00:00:00:00',
+          :iso      => 'P1Y6M'
         }
     }
 
@@ -177,7 +187,8 @@ describe ChronicDuration do
         :short    => '0s',
         :default  => '0 secs',
         :long     => '0 seconds',
-        :chrono   => '0'
+        :chrono   => '0',
+        :iso      => 'PT0S'
       },
         (false) =>
       {
@@ -185,7 +196,8 @@ describe ChronicDuration do
         :short    => nil,
         :default  => nil,
         :long     => nil,
-        :chrono   => '0'
+        :chrono   => '0',
+        :iso      => 'P' # ??? FIXME
       },
     }
 


### PR DESCRIPTION
Fixes #33 - just use `:format => :iso`.

I had to refactor the `result` map loop a bit for the special `T` operator in the middle of the output when an hour, minute, or second exists, but otherwise most of the other code is unaffected. I've also updated the documentation and added results to the spec file. There are some glitches that I'd like to fix if I had more free time (e.g. `0` input produces an output of `P`), but this is enough to satisfy my needs.

I'm submitting this PR as a courtesy with a new version tag (`v0.10.7`), but please let me know if you'd like to see any improvements before including it in your code.

Cheers!